### PR TITLE
Fix inventory data subscription

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1895,9 +1895,9 @@ const DataProvider = ({ children }) => {
         
         const unsubscribes = [
             createSubscription('products', setProducts),
-            createSubscription('inventory', (snapshot) => {
+            createSubscription('inventory', (docs) => {
                 const invData = {};
-                snapshot.forEach(doc => { invData[doc.id] = doc.data(); });
+                docs.forEach(doc => { invData[doc.id] = doc; });
                 setInventory(invData);
                 setInventoryLoaded(true);
             }),


### PR DESCRIPTION
## Summary
- fix inventory subscription mapping in `DataProvider`

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685816c04b688328b734a7a891c43a9f